### PR TITLE
Support to Disable SSL CA Check

### DIFF
--- a/pbstreamdeck/pom.xml
+++ b/pbstreamdeck/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>tv.phantombot</groupId>
 	<artifactId>pbstreamdeck</artifactId>
-	<version>1.0.2.0</version>
+	<version>1.0.3.0</version>
 	<packaging>jar</packaging>
 
 	<name>pbstreamdeck</name>
@@ -34,6 +34,13 @@
 			<artifactId>windows-registry-util</artifactId>
 			<version>0.3</version>
 		</dependency>
+
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+			<version>20180130</version>
+		</dependency>
+
 	</dependencies>
 
 	<build>
@@ -161,7 +168,7 @@
 							<goal>launch4j</goal>
 						</goals>
 						<configuration>
-							<headerType>gui</headerType>
+							<headerType>console</headerType>
 							<jar>${project.build.directory}/${project.artifactId}-${project.version}-shaded.jar</jar>
 							<outfile>${project.build.directory}/PBStreamDeck.exe</outfile>
 							<downloadUrl>http://java.com/download</downloadUrl>

--- a/pbstreamdeck/src/main/java/tv/phantombot/pbstreamdeck/ElgatoStreamDeckConfig.java
+++ b/pbstreamdeck/src/main/java/tv/phantombot/pbstreamdeck/ElgatoStreamDeckConfig.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2018 phantombot.tv
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package tv.phantombot.pbstreamdeck;
+
+import java.util.Map;
+import java.util.stream.Stream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+
+import org.json.JSONObject;
+import org.json.JSONArray;
+import org.json.JSONException;
+
+/**
+ * Interfaces with the Elgato JSON configuration files to automaticelly
+ * update items in the Stream Deck interface.
+ * 
+ * @author IllusionaryOne
+ *
+ */
+
+/**
+ * Notes:
+ * 
+ * Files are stored in:
+ * AppData/Roaming/Elgato/StreamDeck/ProfilesV2/<hash>.sdProfile
+ * 
+ * Location is Column, Row
+ * 
+ * Format: { "Actions": { "2,2": { "Name": "Open", "Settings": {
+ * "openInBrowser": true, "path": "D:\\pbs\\PBStreamDeck.exe d:\\pbs skipsong"
+ * }, "State": 0, "States": [ { "Image": "state0.png", "Title": "Skipsong",
+ * "TitleAlignment": "" } ], "UUID": "com.elgato.streamdeck.system.open" }, },
+ * "DeviceUUID": "@(1)[4057/96/]", "Name": "Default Profile", "Version": "1.0" }
+ * 
+ */
+public class ElgatoStreamDeckConfig {
+	/* x,y -> True/False */
+	private Map<String, Boolean> locationMap = new HashMap<String, Boolean>();
+	
+	/* UUID -> Description in file */
+	private Map<String, String> uuidToNameMap = new HashMap<String, String>();
+	
+	/* UUID -> JSON */
+	private Map<String, JSONObject> jsonMap = new HashMap<String, JSONObject>();
+
+	/**
+	 * Constructor.
+	 */
+	public ElgatoStreamDeckConfig() {
+		initializeLocationMap();
+	}
+
+	/**
+	 * Loads the profiles for the Stream Deck.
+	 */
+	public void loadProfiles(String elgatoDir) throws IOException {
+		Stream<Path> jsonFiles = Files.find(Paths.get(elgatoDir), 10, (path, basicFileAttributes) -> {
+			File file = path.toFile();
+			return !file.isDirectory() && file.getName().contains("manifest.json");
+		});
+
+		jsonFiles.forEach((jsonFilePath) -> {
+			try {
+				byte[] fileData = Files.readAllBytes(jsonFilePath);
+				JSONObject jsonObject = new JSONObject(new String(fileData, "UTF-8"));
+		
+				String[] filePathSplit = jsonFilePath.getParent().toString().split("\\\\");
+				String uuid = filePathSplit[filePathSplit.length - 1];
+				String[] uuidSplit = uuid.split("\\.");
+				uuid = uuidSplit[0];
+				
+				String description = jsonObject.getString("Name");
+			
+				uuidToNameMap.put(uuid, description);
+				jsonMap.put(uuid, jsonObject);
+			} catch (IOException ex) {
+				System.out.println("IOException: " + ex.getMessage());
+			}
+		});
+		
+		jsonFiles.close();
+	}
+
+	/**
+	 * Initializes the locationMap HashMap.
+	 */
+	private void initializeLocationMap() {
+		for (int x = 0; x < 5; x++) {
+			for (int y = 0; y < 3; y++) {
+				String locationStr = Integer.toString(x) + "," + Integer.toString(y);
+				locationMap.put(locationStr, Boolean.FALSE);
+			}
+		}
+	}
+}

--- a/pbstreamdeck/src/main/java/tv/phantombot/pbstreamdeck/PBStreamDeck.java
+++ b/pbstreamdeck/src/main/java/tv/phantombot/pbstreamdeck/PBStreamDeck.java
@@ -42,13 +42,16 @@ public class PBStreamDeck {
 	 */
 	public static void main(String[] args) {
 		String configDir = "";
+		String elgatoConfigDir = "";
 		String fileKey = "";
 		PBStreamDeckProperties properties = new PBStreamDeckProperties();
+		// ElgatoStreamDeckConfig streamDeck = new ElgatoStreamDeckConfig();
 
 		if (args.length < 2) {
 			try {
 				WindowsRegistry registry = WindowsRegistry.getInstance();
 				configDir = registry.readString(HKey.HKCU, "SOFTWARE\\PhantomBot\\StreamDeck", "ConfigDir");
+				// elgatoConfigDir = registry.readString(HKey.HKCU, "SOFTWARE\\PhantomBot\\StreamDeck", "ElgatoConfigDir");
 			} catch (RegistryException ex) {
 				throwErrorGUI("error accessing registry: " + ex.getMessage());
 				return;
@@ -56,6 +59,18 @@ public class PBStreamDeck {
 		} else {
 			configDir = args[1];
 		}
+		
+		/**
+		 * Remove support for this for now.  Still a work in progress and need to release
+		 * a patch for Let's Encrypt.
+		 * 
+		try {
+			streamDeck.loadProfiles(elgatoConfigDir);
+		} catch (IOException ex) {
+			throwErrorGUI("error loading Elgato profiles: " + ex.getMessage());
+			return;
+		}
+		**/
 		
 		if (args.length == 0) {
 			throwErrorGUI("usage: PBStreamDeck [execute key]");
@@ -76,7 +91,7 @@ public class PBStreamDeck {
 			throwErrorGUI("Error loading properties file: " + ex.getMessage());
 			return;
 		}
-
+		
 		fileKey = args[0];
 		String commandOrText = properties.getCommandOrText(fileKey);
 		if (commandOrText == null) {
@@ -85,7 +100,7 @@ public class PBStreamDeck {
 		}
 
 		PhantomBotRESTAPI restAPI = new PhantomBotRESTAPI(properties.getURL(), properties.getBotName(),
-				properties.getAPIAuthKey());
+				properties.getAPIAuthKey(), properties.getSSLCACheck().equals("enable"));
 		String restAPIResult = restAPI.callAPI(commandOrText);
 		if (!restAPIResult.contains("event posted")) {
 			throwErrorGUI(restAPIResult);

--- a/pbstreamdeck/src/main/java/tv/phantombot/pbstreamdeck/PBStreamDeckProperties.java
+++ b/pbstreamdeck/src/main/java/tv/phantombot/pbstreamdeck/PBStreamDeckProperties.java
@@ -79,6 +79,15 @@ public class PBStreamDeckProperties {
 	}
 	
 	/**
+	 * Returns the setting for disabling SSL CA verification.
+	 * 
+	 * @return Disable/enable SSL CA verification.
+	 */
+	public String getSSLCACheck() {
+		return appProperties.getProperty("sslcacheck");
+	}
+	
+	/**
 	 * Returns the data to pass to the PhantomBot REST API.
 	 * 
 	 * @return The command or text to place into chat.

--- a/pbstreamdeck/src/main/java/tv/phantombot/pbstreamdeck/PhantomBotRESTAPI.java
+++ b/pbstreamdeck/src/main/java/tv/phantombot/pbstreamdeck/PhantomBotRESTAPI.java
@@ -24,11 +24,19 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.SocketTimeoutException;
 import java.net.URL;
+
+import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
 
 /**
  * Responsible for interacting with the PhantomBot REST API.
@@ -39,32 +47,79 @@ public class PhantomBotRESTAPI {
 	private String botURL;
 	private String botName;
 	private String botAPIAuthKey;
-	
+	private Boolean sslCACheck = Boolean.TRUE;
+
 	/**
 	 * Constructor for PhantomBotRESTAPI
 	 * 
-	 * @param botURL The URL that PhantomBot is hosting the REST API service on.
-	 * @param botName The name of the PhantomBot instance, will be used as the actor.
-	 * @param botAPIAuthKey The webauth key from botlogin.txt.
+	 * @param botURL
+	 *            The URL that PhantomBot is hosting the REST API service on.
+	 * @param botName
+	 *            The name of the PhantomBot instance, will be used as the actor.
+	 * @param botAPIAuthKey
+	 *            The webauth key from botlogin.txt.
 	 */
-	public PhantomBotRESTAPI(String botURL, String botName, String botAPIAuthKey) {
+	public PhantomBotRESTAPI(String botURL, String botName, String botAPIAuthKey, Boolean sslCACheck) {
 		this.botURL = botURL;
 		this.botName = botName;
 		this.botAPIAuthKey = botAPIAuthKey;
+		this.sslCACheck = sslCACheck;
 	}
-	
+
 	/**
 	 * Calls the PhantomBot REST API
 	 * 
-	 * @param message The message/command to send to the REST API.
-	 * @return A String object that contains the value back from REST or another error message.
+	 * @param message
+	 *            The message/command to send to the REST API.
+	 * @return A String object that contains the value back from REST or another
+	 *         error message.
 	 */
 	public String callAPI(String message) {
 		URL url;
 		InputStream inputStream = null;
 		HttpsURLConnection httpsUrlConn;
 		HttpURLConnection httpUrlConn;
-		
+
+		/**
+		 * Disable the CA verification on SSL certificates.  Some certificates, such as Let's 
+		 * Encrypt, can have problems with Java.  While this is not recommended for accessing
+		 * sites in general, the assumption is that the operator of this program trusts the
+		 * certificate and server that PhantomBot is running on.
+		 */
+		if (sslCACheck == Boolean.FALSE) {
+			TrustManager[] trustManager = new TrustManager[] {
+				new X509TrustManager() {
+					public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+						return new java.security.cert.X509Certificate[] {};
+					}
+					@Override
+					public void checkClientTrusted(X509Certificate[] chain,
+							String authType) throws CertificateException {
+					}
+					@Override
+					public void checkServerTrusted(X509Certificate[] chain,
+							String authType) throws CertificateException {
+					}
+				}
+			};
+			
+			try {
+				SSLContext sc = SSLContext.getInstance("TLS");
+				sc.init(null, trustManager, new java.security.SecureRandom());
+				HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+			} catch (Exception ex) {
+				return "exception trying to override SSL CA check: " + ex.getMessage();
+			}
+			
+	        HostnameVerifier hostnameVerifier = new HostnameVerifier() {
+	            public boolean verify(String hostname, SSLSession session) {
+	                return true;
+	            }
+	        };
+	        
+	        HttpsURLConnection.setDefaultHostnameVerifier(hostnameVerifier);
+		}
+
 		try {
 			url = new URL(botURL);
 			if (botURL.startsWith("https://")) {
@@ -72,39 +127,41 @@ public class PhantomBotRESTAPI {
 				httpsUrlConn.setDoInput(true);
 				httpsUrlConn.setDoOutput(true);
 				httpsUrlConn.setRequestMethod("PUT");
-				
+
 				httpsUrlConn.addRequestProperty("webauth", botAPIAuthKey);
 				httpsUrlConn.addRequestProperty("user", botName);
-				httpsUrlConn.addRequestProperty("message",  message);
+				httpsUrlConn.addRequestProperty("message", message);
 				httpsUrlConn.connect();
-				
+
 				if (httpsUrlConn.getResponseCode() == 200) {
 					inputStream = httpsUrlConn.getInputStream();
 				} else {
 					inputStream = httpsUrlConn.getErrorStream();
 				}
 
-				BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, Charset.forName("UTF-8")));
+				BufferedReader reader = new BufferedReader(
+						new InputStreamReader(inputStream, Charset.forName("UTF-8")));
 				return "API Returned: " + readAll(reader);
 			} else {
 				httpUrlConn = (HttpURLConnection) url.openConnection();
 				httpUrlConn.setDoInput(true);
 				httpUrlConn.setDoOutput(true);
 				httpUrlConn.setRequestMethod("PUT");
-				
+
 				httpUrlConn.addRequestProperty("webauth", botAPIAuthKey);
 				httpUrlConn.addRequestProperty("user", botName);
-				httpUrlConn.addRequestProperty("message",  message);
+				httpUrlConn.addRequestProperty("message", message);
 				httpUrlConn.connect();
-				
+
 				if (httpUrlConn.getResponseCode() == 200) {
 					inputStream = httpUrlConn.getInputStream();
 				} else {
 					inputStream = httpUrlConn.getErrorStream();
 				}
 
-				BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, Charset.forName("UTF-8")));
-				return "API Returned: " + readAll(reader);				
+				BufferedReader reader = new BufferedReader(
+						new InputStreamReader(inputStream, Charset.forName("UTF-8")));
+				return "API Returned: " + readAll(reader);
 			}
 		} catch (UnsupportedEncodingException ex) {
 			return "Failed to decode data from API.";
@@ -120,19 +177,19 @@ public class PhantomBotRESTAPI {
 			return "A general exception has occurred: " + ex.getMessage();
 		}
 	}
-	
-    /**
-     * Reads data from a stream.
-     * 
-     * @return A String representing the data read from the stream.
-     */
-    private static String readAll(Reader rd) throws IOException {
-        StringBuilder sb = new StringBuilder();
-        int cp;
-        while ((cp = rd.read()) != -1) {
-            sb.append((char) cp);
-        }
-        return sb.toString();
-    }
+
+	/**
+	 * Reads data from a stream.
+	 * 
+	 * @return A String representing the data read from the stream.
+	 */
+	private static String readAll(Reader rd) throws IOException {
+		StringBuilder sb = new StringBuilder();
+		int cp;
+		while ((cp = rd.read()) != -1) {
+			sb.append((char) cp);
+		}
+		return sb.toString();
+	}
 
 }

--- a/pbstreamdeck/src/main/resources/README.txt
+++ b/pbstreamdeck/src/main/resources/README.txt
@@ -17,7 +17,18 @@ key that you want to execute.  Using the runmods example:
 The file pblogo.png is included to use in Stream Deck as a replacement image
 for the default one provided for the button.  This is located in the
 folder with the executable.
+
+If you run this program and receive the following error:
+
+	unable to find valid certification path to requested target
 	
+Then Java does not trust the SSL certificate that you use with your PhantomBot
+instance.  You will either need to manually add that certificate to the Java
+cacerts store (please use Google to determine how to do this) or you may
+set the following when you are editing your properties file:
+
+	sslcacheck=disable
+
 For more information, please visit:
 
 	https://community.phantombot.tv/t/phantombot-streamdeck-interface/3999

--- a/pbstreamdeck/src/main/resources/innosetup_config.iss
+++ b/pbstreamdeck/src/main/resources/innosetup_config.iss
@@ -7,6 +7,7 @@
 #define MyAppURL "https://phantombot.tv"
 #define MyAppExeName "PBStreamDeck.exe"
 #define LocalConfigDir "{localappdata}\PhantomBot\StreamDeck"
+#define ElgatoConfigDir "{userappdata}\Elgato\StreamDeck"
 
 [Setup]
 ; NOTE: The value of AppId uniquely identifies this application.
@@ -36,7 +37,7 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 [Files]
 Source: "C:\Users\illus\git\PBStreamDeck\pbstreamdeck\target\PBStreamDeck.exe"; DestDir: "{app}"; Flags: ignoreversion
 Source: "C:\Users\illus\git\PBStreamDeck\pbstreamdeck\target\README.txt"; DestDir: "{app}"; Flags: ignoreversion
-Source: "C:\Users\illus\git\PBStreamDeck\pbstreamdeck\target\streamdeck.properties.txt"; DestDir: "{#LocalConfigDir}"; Flags: ignoreversion
+Source: "C:\Users\illus\git\PBStreamDeck\pbstreamdeck\target\streamdeck.properties.txt"; DestDir: "{#LocalConfigDir}"; Flags: onlyifdoesntexist
 Source: "C:\Users\illus\git\PBStreamDeck\pbstreamdeck\target\pblogo.png"; DestDir: "{app}"; Flags: ignoreversion
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
@@ -49,3 +50,4 @@ Name: "{group}\{cm:UninstallProgram,{#MyAppName}}"; Filename: "{uninstallexe}"
 [Registry]
 Root: HKCU; Subkey: "Software\PhantomBot\StreamDeck"; Flags: uninsdeletekey
 Root: HKCU; Subkey: "Software\PhantomBot\StreamDeck"; ValueType: string; ValueName: "ConfigDir"; ValueData: "{#LocalConfigDir}"
+Root: HKCU; Subkey: "Software\PhantomBot\StreamDeck"; ValueType: string; ValueName: "ElgatoConfigDir"; ValueData: "{#ElgatoConfigDir}"

--- a/pbstreamdeck/src/main/resources/streamdeck.properties.txt
+++ b/pbstreamdeck/src/main/resources/streamdeck.properties.txt
@@ -25,6 +25,14 @@ boturl=http://localhost:25000
 #
 botapiauthkey=abcdefghijklmop1234
 
+# Either enable or disable the SSL CA check. This should always 
+# be enable unless you have an exception when connecting to your
+# PhantomBot instance that is related to an SSL error.  You
+# have two choices.  Either add your certificate directly to 
+# your Java installation's cacerts keystore or set this to disable
+#
+sslcacheck=enable
+
 # Commands to run or things to say in chat.  The key is the command
 # line option to pass in to execute the command/chat text.
 #


### PR DESCRIPTION
Start to Support Elgato JSON Processing

**pom.xml**
- Version update.
- Add JSON support.

**ElgatoStreamDeckConfig.java**
- Start to support processing of Elgato JSON configuration files.

**PBStreamDeck.java**
- Configure the REST API call to verify the SSL CA or not.
- Leave in code for starting to handle Elgato Stream Deck configuration, but commented out.

**PBStreamDeckProperties.java**
- Add new properties setting for SSL CA handling.

**PhantomBotRESTAPI.java**
- Provide ability to disable the SSL CA handling.

**README.txt**
- Updated with new configuration setting.

**innosetup_config.iss**
- Version update.

**streamdeck.properties.txt**
- Updated with new configuration setting.